### PR TITLE
exclude hydra logs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ cython_debug/
 /data
 
 #hydra
-outputs
+hydra_logs/training_outputs/*
+!hydra_logs/training_outputs/.gitkeep


### PR DESCRIPTION
Changed gitignore to exclude the contents of the new hydra logs folder.